### PR TITLE
FIX - division by zeroerror on GET products

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -66,7 +66,7 @@ class Product(SafeDeleteModel):
             avg = total_rating / len(ratings)
             return avg
         except:
-            return "no ratings"
+            return 0
 
     class Meta:
         verbose_name = ("product")

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -58,12 +58,15 @@ class Product(SafeDeleteModel):
             number -- The average rating for the product
         """
         ratings = ProductRating.objects.filter(product=self)
-        total_rating = 0
-        for rating in ratings:
-            total_rating += rating.rating
+        try:
+            total_rating = 0
+            for rating in ratings:
+                total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
-        return avg
+            avg = total_rating / len(ratings)
+            return avg
+        except:
+            return "no ratings"
 
     class Meta:
         verbose_name = ("product")


### PR DESCRIPTION
Added a try/except block to handle a product not having any reviews.

## Changes

- Added a try/except block to the average_rating property on the product model. Existing code did not handle cases where number of product reviews == 0. 

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Seed database
- [ ] Run GET requests on ALL products
- [ ] Run GET request on single product


## Related Issues

- Fixes #15 