### PR TITLE
Feature - client can specify a minimum price when filtering products

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -250,6 +250,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        min_price = self.request.query_params.get('min_price', None)
 
         if order is not None:
             order_filter = order
@@ -273,6 +274,9 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if min_price is not None:
+            products = products.filter(price__gte=min_price)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
Client can specify a minimum price on requests for all products.

## Changes

- Added additional query param on products list.

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/products?min_price=1250` Returns a list of all products with a price >= 1250.

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 10,
    "name": "Land Cruiser",
    "price": 1768.97,
    "number_sold": 0,
    "description": "2008 Toyota",
    "quantity": 3,
    "created_date": "2019-10-07",
    "location": "Niverville",
    "image_path": null,
    "average_rating": 0
}
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run GET requests to ```/products?min_price=NUM``` with different values in place of num.


## Related Issues

- Fixes #17 