### PR TITLE
FIX - product number_sold filter

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -268,7 +268,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
Fixed a bug where client could not filter by number of products sold. 

## Changes

- Fixed incorrect operator on filter

## Requests / Responses

No changes to request/response.

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Make get request to ```/products?number_sold=2```


## Related Issues

- Fixes #21 