### PR TITLE
Fix - duplicate line items on cart response

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -102,12 +102,17 @@ class Orders(ViewSet):
         @apiSuccessExample {json} Success
             HTTP/1.1 204 No Content
         """
-        customer = Customer.objects.get(user=request.auth.user)
-        order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
-        order.save()
+        try:
+            customer = Customer.objects.get(user=request.auth.user)
+            order = Order.objects.get(pk=pk, customer=customer)
+            payment_type = Payment.objects.get(id=int(request.data["payment_type"]), customer=customer)
+            order.payment_type = payment_type
+            order.save()
 
-        return Response({}, status=status.HTTP_204_NO_CONTENT)
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+        except Payment.DoesNotExist:
+            return Response({'message': 'Payment type does not exist'}, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
     def list(self, request):
         """

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -203,7 +203,6 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -253,8 +253,9 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
-                print(open_order)
+                open_order = Order.objects.get(
+                    customer=current_user, payment_type=None)
+                
             except Order.DoesNotExist as ex:
                 open_order = Order()
                 open_order.created_date = datetime.datetime.now()


### PR DESCRIPTION
Fixed response from /profile/cart to only hold lineitems once.

## Changes

- Removed line of code that added the duplicate line_items to response

## Requests / Responses

**Request**

No changes to request

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 11,
    "url": "http://localhost:8000/orders/11",
    "created_date": "2021-06-03",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/7",
    "lineitems": [
        {
            "id": 11,
            "product": {
                "id": 88,
                "name": "Element",
                "price": 1727.41,
                "number_sold": 1,
                "description": "2003 Honda",
                "quantity": 3,
                "created_date": "2019-05-28",
                "location": "Dukoh",
                "image_path": null,
                "average_rating": 0
            }
        }
    ],
    "size": 1
}
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] GET request to /profiles/cart


## Related Issues

- Fixes #24 